### PR TITLE
Docker workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Create and publish Docker image
+
+# run every time a change is pushed to the `master` branch
+on:
+  push:
+    branches: ['master']
+
+# define container registry domain and docker image name to publish
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'cryptool-org'
+
+    # permissions for code checkout and package push (granted to `GITHUB_TOKEN`)
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=git-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          pull: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# base python image version
+ARG PYTHON_VERSION=3.8-slim-bookworm
+
+
+# base image
+# ============
+FROM python:${PYTHON_VERSION} as base
+
+# configure python
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# setup virtualenv
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+
+# build image
+# =============
+FROM base as build-image
+
+# install dependencies
+COPY requirements.txt /opt/requirements.txt
+RUN sed -i -re 's/^tensorflow\b/tensorflow-cpu/g' /opt/requirements.txt
+RUN set -ex \
+    && python -m venv --symlinks --clear "$VIRTUAL_ENV" \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /opt/requirements.txt \
+    && pip install --no-cache-dir "fastapi" "uvicorn[standard]"
+
+
+# api image
+# ======================
+FROM base as api
+
+EXPOSE 4343
+
+# copy virtualenv
+COPY --from=build-image "$VIRTUAL_ENV" "$VIRTUAL_ENV"
+
+# create source directory
+RUN mkdir -p /opt/ncid/
+WORKDIR /opt/ncid
+
+# change to non-root user
+RUN useradd apiuser
+USER apiuser
+
+COPY --chown=apiuser:apiuser . /opt/ncid
+
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "4343"]


### PR DESCRIPTION
Add multi-stage `Dockerfile` based on the work by @MaikBastian. For the time being, we stick with Python 3.8.

Add a workflow for GitHub Actions to build and publish the Docker image to GitHub's Container Registry. This only runs for the `master` branch in the source repository, not for forks.