### PR TITLE
Fix calculation of cdd statistic

### DIFF
--- a/cipherTypeDetection/featureCalculations.py
+++ b/cipherTypeDetection/featureCalculations.py
@@ -359,7 +359,7 @@ var columnar_calcs = function(){
         var i,j,k;
         var max,sum;
         var index,dif,long_corr,short_corr;
-        max = 0;
+        max = -1;
 
         for (j= col;j<key_len;j++) {
         long_corr = short_corr = 0;


### PR DESCRIPTION
For specific ciphertexts the wrong initialization of a variable would insert undefined state into the internal logic of the 'cdd' statistic. This lead to many thrown (and catched) excpetions, which decreased the performance significantly.

An example of such a ciphertext is: 'ooooo' or other sequences of the same letter.