### PR TITLE
Future proof code for addition of new cipher types outside current cipher groups

### DIFF
--- a/cipherTypeDetection/cipherStatisticsDataset.py
+++ b/cipherTypeDetection/cipherStatisticsDataset.py
@@ -452,7 +452,7 @@ class PlaintextPathsDataset:
 
         key_lengths_count = 0
         for cipher_t in self._cipher_types:
-            index = self._cipher_types.index(cipher_t)
+            index = config.CIPHER_TYPES.index(cipher_t)
             if isinstance(config.KEY_LENGTHS[index], list):
                 key_lengths_count += len(config.KEY_LENGTHS[index])
             else:
@@ -610,15 +610,14 @@ class PlaintextLine2CipherStatisticsWorker:
 
         for line in plaintexts:
             for cipher_type in self._cipher_types:
-                index = config.cipher_types.index(cipher_type)
-                label = self._cipher_types.index(cipher_type)
+                label = config.cipher_types.index(cipher_type)
                 if isinstance(config.key_lengths[label], list):
                     key_lengths = config.key_lengths[label]
                 else:
                     key_lengths = [config.key_lengths[label]]
                 for key_length in key_lengths:
                     try:
-                        ciphertext = encrypt(line, index, key_length, self._keep_unknown_symbols)
+                        ciphertext = encrypt(line, label, key_length, self._keep_unknown_symbols)
                     except:
                         multiprocessing_logger.error(f"Could not encrypt line with cipher "
                                                      f"'{cipher_type}'. and key length {key_length}. "

--- a/cipherTypeDetection/cipherStatisticsDataset.py
+++ b/cipherTypeDetection/cipherStatisticsDataset.py
@@ -362,7 +362,7 @@ class RotorCiphertextsDataset:
     @property
     def is_initialized(self):
         """Indicates whether the dataset was initialized with input data."""
-        return self._number_of_cipher_classes != 0
+        return self._number_of_cipher_classes != 0 and self._batch_size > 0
     
     def _are_files_closed(self):
         """Returns True if at least one ciphertext file is closed."""
@@ -472,7 +472,7 @@ class PlaintextPathsDataset:
     @property
     def is_initialized(self):
         """Indicates whether the dataset was initialized with input data."""
-        return len(self._plaintext_paths) != 0 and len(self._cipher_types) != 0
+        return len(self._plaintext_paths) != 0 and len(self._cipher_types) != 0 and self._batch_size > 0
 
     def __iter__(self):
         return self

--- a/cipherTypeDetection/train.py
+++ b/cipherTypeDetection/train.py
@@ -1030,8 +1030,7 @@ def expand_cipher_groups(cipher_types):
             expanded.append(config.CIPHER_TYPES[i])
     elif config.ALL in expanded:
         del expanded[expanded.index(config.ALL)]
-        for i in range(61):
-            expanded.append(config.CIPHER_TYPES[i])
+        expanded.extend(config.CIPHER_TYPES)
     return expanded
 
 def main():

--- a/cipherTypeDetection/train.py
+++ b/cipherTypeDetection/train.py
@@ -485,8 +485,7 @@ def load_plaintext_datasets_from_disk(args, requested_cipher_types, batch_size):
         `CipherStatisticsDataset`s for training and testing.
     """
     # Filter cipher_types to exclude non-plaintext ciphers
-    aca_cipher_types = [config.CIPHER_TYPES[i] for i in range(56)]
-    cipher_types = [type for type in requested_cipher_types if type in aca_cipher_types]
+    cipher_types = [type for type in requested_cipher_types if type not in config.ROTOR_CIPHER_TYPES]
 
     # Get all paths to plaintext files in the `plaintext_input_directory`
     plaintext_files = []


### PR DESCRIPTION
The code will now consider new cipher types added to `CIPHER_TYPES` in `config.py`, even when their position clashes with the cipher groups 'aca' and ' rotor'.